### PR TITLE
Renaming / refactoring `MxVector` / `MxMatrix`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,6 @@ add_library(lego1 SHARED
   LEGO1/mxloopingflcpresenter.cpp
   LEGO1/mxloopingmidipresenter.cpp
   LEGO1/mxloopingsmkpresenter.cpp
-  
   LEGO1/mxmediamanager.cpp
   LEGO1/mxmediapresenter.cpp
   LEGO1/mxmidipresenter.cpp
@@ -183,7 +182,6 @@ add_library(lego1 SHARED
   LEGO1/mxtype17notificationparam.cpp
   LEGO1/mxvariable.cpp
   LEGO1/mxvariabletable.cpp
-  
   LEGO1/mxvideomanager.cpp
   LEGO1/mxvideoparam.cpp
   LEGO1/mxvideoparamflags.cpp
@@ -201,11 +199,11 @@ add_library(lego1 SHARED
   LEGO1/racestate.cpp
   LEGO1/radio.cpp
   LEGO1/radiostate.cpp
-  LEGO1/realtime/mxmatrix.cpp
-  LEGO1/realtime/mxvector.cpp
+  LEGO1/realtime/matrix.cpp
   LEGO1/realtime/orientableroi.cpp
   LEGO1/realtime/realtime.cpp
   LEGO1/realtime/realtimeview.cpp
+  LEGO1/realtime/vector.cpp
   LEGO1/registrationbook.cpp
   LEGO1/score.cpp
   LEGO1/scorestate.cpp
@@ -251,7 +249,7 @@ if (ISLE_BUILD_APP)
     ISLE/res/isle.rc
     ISLE/isleapp.cpp
     ISLE/define.cpp
-   "LEGO1/realtime/mxmatrix.h" "LEGO1/realtime/mxvector.h" "LEGO1/realtime/mxmatrix.cpp" "LEGO1/realtime/mxvector.cpp")
+  )
 
   # Include LEGO1 headers in ISLE
   target_include_directories(isle PRIVATE "${CMAKE_SOURCE_DIR}/LEGO1")

--- a/LEGO1/helicopter.h
+++ b/LEGO1/helicopter.h
@@ -3,7 +3,7 @@
 
 #include "helicopterstate.h"
 #include "islepathactor.h"
-#include "realtime/mxmatrix.h"
+#include "realtime/matrix.h"
 
 // VTABLE 0x100d40f8
 // SIZE 0x230
@@ -32,11 +32,11 @@ public:
 	virtual ~Helicopter() override; // vtable+0x0
 
 protected:
-	MxMatrixData m_unk160;
-	MxMatrixData m_unk1a8;
+	MatrixData m_unk160;
+	MatrixData m_unk1a8;
 	undefined4 m_unk1f0;
-	MxVector4Data m_unk1f4;
-	MxVector4Data m_unk20c;
+	Vector4Data m_unk1f4;
+	Vector4Data m_unk20c;
 	undefined4 m_unk224;
 	HelicopterState* m_state;
 	MxAtomId m_unk22c;

--- a/LEGO1/helicopter.h
+++ b/LEGO1/helicopter.h
@@ -32,8 +32,8 @@ public:
 	virtual ~Helicopter() override; // vtable+0x0
 
 protected:
-	MatrixData m_unk160;
-	MatrixData m_unk1a8;
+	Matrix4Data m_unk160;
+	Matrix4Data m_unk1a8;
 	undefined4 m_unk1f0;
 	Vector4Data m_unk1f4;
 	Vector4Data m_unk20c;

--- a/LEGO1/legoentity.cpp
+++ b/LEGO1/legoentity.cpp
@@ -36,7 +36,7 @@ void LegoEntity::ResetWorldTransform(MxBool p_inVehicle)
 }
 
 // OFFSET: LEGO1 0x10010790 STUB
-void LegoEntity::SetWorldTransform(MxVector3& p_loc, MxVector3& p_dir, MxVector3& p_up)
+void LegoEntity::SetWorldTransform(Vector3Impl& p_loc, Vector3Impl& p_dir, Vector3Impl& p_up)
 {
 	// TODO
 }

--- a/LEGO1/legoentity.h
+++ b/LEGO1/legoentity.h
@@ -6,7 +6,7 @@
 #include "legoroi.h"
 #include "mxdsobject.h"
 #include "mxentity.h"
-#include "realtime/mxvector.h"
+#include "realtime/vector.h"
 
 // VTABLE 0x100d4858
 // SIZE 0x68 (probably)
@@ -32,12 +32,12 @@ public:
 		return !strcmp(name, LegoEntity::ClassName()) || MxEntity::IsA(name);
 	}
 
-	virtual MxResult InitFromMxDSObject(MxDSObject& p_dsObject);                         // vtable+0x18
-	virtual void Destroy(MxBool p_fromDestructor);                                       // vtable+0x1c
-	virtual void ParseAction(char*);                                                     // vtable+0x20
-	virtual void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2);                 // vtable+0x24
-	virtual void SetWorldTransform(MxVector3& p_loc, MxVector3& p_dir, MxVector3& p_up); // vtable+0x28
-	virtual void ResetWorldTransform(MxBool p_inVehicle);                                // vtable+0x2c
+	virtual MxResult InitFromMxDSObject(MxDSObject& p_dsObject);                               // vtable+0x18
+	virtual void Destroy(MxBool p_fromDestructor);                                             // vtable+0x1c
+	virtual void ParseAction(char*);                                                           // vtable+0x20
+	virtual void SetROI(LegoROI* p_roi, MxBool p_bool1, MxBool p_bool2);                       // vtable+0x24
+	virtual void SetWorldTransform(Vector3Impl& p_loc, Vector3Impl& p_dir, Vector3Impl& p_up); // vtable+0x28
+	virtual void ResetWorldTransform(MxBool p_inVehicle);                                      // vtable+0x2c
 	// OFFSET: LEGO1 0x10001090
 	virtual void SetWorldSpeed(MxFloat p_worldSpeed) { m_worldSpeed = p_worldSpeed; } // vtable+0x30
 	virtual void VTable0x34();                                                        // vtable+0x34
@@ -54,12 +54,12 @@ protected:
 
 	undefined m_unk10;
 	undefined m_unk11;
-	MxVector3Data m_worldLocation;  // 0x14
-	MxVector3Data m_worldDirection; // 0x28
-	MxVector3Data m_worldUp;        // 0x3c
-	MxFloat m_worldSpeed;           // 0x50
-	LegoROI* m_roi;                 // 0x54
-	MxBool m_cameraFlag;            // 0x58
+	Vector3Data m_worldLocation;  // 0x14
+	Vector3Data m_worldDirection; // 0x28
+	Vector3Data m_worldUp;        // 0x3c
+	MxFloat m_worldSpeed;         // 0x50
+	LegoROI* m_roi;               // 0x54
+	MxBool m_cameraFlag;          // 0x58
 	undefined m_unk59;
 	// For tokens from the extra string that look like this:
 	// "Action:openram;\lego\scripts\Race\CarRaceR;0"

--- a/LEGO1/mxdsaction.h
+++ b/LEGO1/mxdsaction.h
@@ -3,7 +3,7 @@
 
 #include "mxdsobject.h"
 #include "mxtypes.h"
-#include "realtime/mxvector.h"
+#include "realtime/vector.h"
 
 class MxOmni;
 
@@ -62,7 +62,7 @@ public:
 	inline MxLong GetStartTime() const { return m_startTime; }
 	inline MxS32 GetLoopCount() { return m_loopCount; }
 	inline void SetLoopCount(MxS32 p_loopCount) { m_loopCount = p_loopCount; }
-	inline const MxVector3Data& GetLocation() const { return m_location; }
+	inline const Vector3Data& GetLocation() const { return m_location; }
 	inline void SetUnknown84(MxCore* p_unk84) { m_unk84 = p_unk84; }
 	inline MxCore* GetUnknown8c() { return m_unk8c; }
 	inline void SetUnknown8c(MxCore* p_unk8c) { m_unk8c = p_unk8c; }
@@ -71,20 +71,20 @@ public:
 	inline MxBool IsBit3() const { return m_flags & Flag_Bit3; }
 
 protected:
-	MxU32 m_sizeOnDisk;        // 0x2c
-	MxU32 m_flags;             // 0x30
-	MxLong m_startTime;        // 0x34
-	MxLong m_duration;         // 0x38
-	MxS32 m_loopCount;         // 0x3c
-	MxVector3Data m_location;  // 0x40
-	MxVector3Data m_direction; // 0x54
-	MxVector3Data m_up;        // 0x68
-	char* m_extraData;         // 0x7c
-	MxU16 m_extraLength;       // 0x80
-	MxCore* m_unk84;           // 0x84
-	undefined4 m_unk88;        // 0x88
-	MxCore* m_unk8c;           // 0x8c
-	MxLong m_unkTimingField;   // 0x90
+	MxU32 m_sizeOnDisk;      // 0x2c
+	MxU32 m_flags;           // 0x30
+	MxLong m_startTime;      // 0x34
+	MxLong m_duration;       // 0x38
+	MxS32 m_loopCount;       // 0x3c
+	Vector3Data m_location;  // 0x40
+	Vector3Data m_direction; // 0x54
+	Vector3Data m_up;        // 0x68
+	char* m_extraData;       // 0x7c
+	MxU16 m_extraLength;     // 0x80
+	MxCore* m_unk84;         // 0x84
+	undefined4 m_unk88;      // 0x88
+	MxCore* m_unk8c;         // 0x8c
+	MxLong m_unkTimingField; // 0x90
 };
 
 #endif // MXDSACTION_H

--- a/LEGO1/mxpresenter.cpp
+++ b/LEGO1/mxpresenter.cpp
@@ -123,7 +123,7 @@ MxResult MxPresenter::StartAction(MxStreamController*, MxDSAction* p_action)
 
 	this->m_action = p_action;
 
-	const MxVector3Data& location = this->m_action->GetLocation();
+	const Vector3Data& location = this->m_action->GetLocation();
 	MxS32 previousTickleState = this->m_currentTickleState;
 
 	this->m_location = MxPoint32(this->m_action->GetLocation()[0], this->m_action->GetLocation()[1]);

--- a/LEGO1/realtime/matrix.cpp
+++ b/LEGO1/realtime/matrix.cpp
@@ -1,5 +1,5 @@
 
-#include "mxmatrix.h"
+#include "matrix.h"
 
 #include "../decomp.h"
 #include "math.h"
@@ -7,65 +7,65 @@
 #include <memory.h>
 
 DECOMP_SIZE_ASSERT(Matrix4, 0x40);
-DECOMP_SIZE_ASSERT(MxMatrix, 0x8);
-DECOMP_SIZE_ASSERT(MxMatrixData, 0x48);
+DECOMP_SIZE_ASSERT(MatrixImpl, 0x8);
+DECOMP_SIZE_ASSERT(MatrixData, 0x48);
 
 // OFFSET: LEGO1 0x10002320
-void MxMatrix::EqualsMatrixData(const Matrix4& p_matrix)
+void MatrixImpl::EqualsMatrixData(const Matrix4& p_matrix)
 {
 	*m_data = p_matrix;
 }
 
 // OFFSET: LEGO1 0x10002340
-void MxMatrix::EqualsMxMatrix(const MxMatrix* p_other)
+void MatrixImpl::EqualsMatrixImpl(const MatrixImpl* p_other)
 {
 	*m_data = *p_other->m_data;
 }
 
 // OFFSET: LEGO1 0x10002360
-void MxMatrix::AnotherSetData(Matrix4& p_data)
+void MatrixImpl::AnotherSetData(Matrix4& p_data)
 {
 	m_data = &p_data;
 }
 
 // OFFSET: LEGO1 0x10002370
-void MxMatrix::SetData(Matrix4& p_data)
+void MatrixImpl::SetData(Matrix4& p_data)
 {
 	m_data = &p_data;
 }
 
 // OFFSET: LEGO1 0x10002380
-const Matrix4* MxMatrix::GetData() const
+const Matrix4* MatrixImpl::GetData() const
 {
 	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002390
-Matrix4* MxMatrix::GetData()
+Matrix4* MatrixImpl::GetData()
 {
 	return m_data;
 }
 
 // OFFSET: LEGO1 0x100023a0
-const float* MxMatrix::Element(int p_row, int p_col) const
+const float* MatrixImpl::Element(int p_row, int p_col) const
 {
 	return &(*m_data)[p_row][p_col];
 }
 
 // OFFSET: LEGO1 0x100023c0
-float* MxMatrix::Element(int p_row, int p_col)
+float* MatrixImpl::Element(int p_row, int p_col)
 {
 	return &(*m_data)[p_row][p_col];
 }
 
 // OFFSET: LEGO1 0x100023e0
-void MxMatrix::Clear()
+void MatrixImpl::Clear()
 {
 	memset(m_data, 0, 16 * sizeof(float));
 }
 
 // OFFSET: LEGO1 0x100023f0
-void MxMatrix::SetIdentity()
+void MatrixImpl::SetIdentity()
 {
 	Clear();
 	(*m_data)[0][0] = 1.0f;
@@ -75,7 +75,7 @@ void MxMatrix::SetIdentity()
 }
 
 // OFFSET: LEGO1 0x10002430
-MxMatrix* MxMatrix::operator+=(const Matrix4& p_matrix)
+MatrixImpl* MatrixImpl::operator+=(const Matrix4& p_matrix)
 {
 	for (int i = 0; i < 16; ++i)
 		((float*) m_data)[i] += ((float*) &p_matrix)[i];
@@ -85,7 +85,7 @@ MxMatrix* MxMatrix::operator+=(const Matrix4& p_matrix)
 // Matches but instructions are significantly out of order. Probably not wrong
 // code given that the very similar SetTranslation does match.
 // OFFSET: LEGO1 0x10002460
-void MxMatrix::TranslateBy(const float* p_x, const float* p_y, const float* p_z)
+void MatrixImpl::TranslateBy(const float* p_x, const float* p_y, const float* p_z)
 {
 	((float*) m_data)[12] += *p_x;
 	((float*) m_data)[13] += *p_y;
@@ -93,7 +93,7 @@ void MxMatrix::TranslateBy(const float* p_x, const float* p_y, const float* p_z)
 }
 
 // OFFSET: LEGO1 0x100024a0
-void MxMatrix::SetTranslation(const float* p_x, const float* p_y, const float* p_z)
+void MatrixImpl::SetTranslation(const float* p_x, const float* p_y, const float* p_z)
 {
 	(*m_data)[3][0] = *p_x;
 	(*m_data)[3][1] = *p_y;
@@ -101,7 +101,7 @@ void MxMatrix::SetTranslation(const float* p_x, const float* p_y, const float* p
 }
 
 // OFFSET: LEGO1 0x100024d0
-void MxMatrix::EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b)
+void MatrixImpl::EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b)
 {
 	float* cur = (float*) m_data;
 	for (int row = 0; row < 4; ++row) {
@@ -116,7 +116,7 @@ void MxMatrix::EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b)
 }
 
 // OFFSET: LEGO1 0x10002530
-void MxMatrix::EqualsMxProduct(const MxMatrix* p_a, const MxMatrix* p_b)
+void MatrixImpl::EqualsMxProduct(const MatrixImpl* p_a, const MatrixImpl* p_b)
 {
 	EqualsDataProduct(*p_a->m_data, *p_b->m_data);
 }
@@ -125,7 +125,7 @@ void MxMatrix::EqualsMxProduct(const MxMatrix* p_a, const MxMatrix* p_b)
 // be manually worked out. Included since I at least figured out what it was
 // doing with rotateIndex and what overall operation it's trying to do.
 // OFFSET: LEGO1 0x10002550 STUB
-void MxMatrix::ToQuaternion(MxVector4* p_outQuat)
+void MatrixImpl::ToQuaternion(Vector4Impl* p_outQuat)
 {
 	/*
 	float trace = m_data[0] + m_data[5] + m_data[10];
@@ -168,19 +168,19 @@ void MxMatrix::ToQuaternion(MxVector4* p_outQuat)
 // No idea what this function is doing and it will be hard to tell until
 // we have a confirmed usage site.
 // OFFSET: LEGO1 0x10002710 STUB
-MxResult MxMatrix::FUN_10002710(const MxVector3* p_vec)
+int MatrixImpl::FUN_10002710(const Vector3Impl* p_vec)
 {
-	return FAILURE;
+	return -1;
 }
 
 // OFFSET: LEGO1 0x10002850
-void MxMatrix::operator=(const MxMatrix& p_other)
+void MatrixImpl::operator=(const MatrixImpl& p_other)
 {
-	EqualsMxMatrix(&p_other);
+	EqualsMatrixImpl(&p_other);
 }
 
 // OFFSET: LEGO1 0x10002860
-void MxMatrixData::operator=(const MxMatrixData& p_other)
+void MatrixData::operator=(const MatrixData& p_other)
 {
-	EqualsMxMatrix(&p_other);
+	EqualsMatrixImpl(&p_other);
 }

--- a/LEGO1/realtime/matrix.cpp
+++ b/LEGO1/realtime/matrix.cpp
@@ -7,65 +7,65 @@
 #include <memory.h>
 
 DECOMP_SIZE_ASSERT(Matrix4, 0x40);
-DECOMP_SIZE_ASSERT(MatrixImpl, 0x8);
-DECOMP_SIZE_ASSERT(MatrixData, 0x48);
+DECOMP_SIZE_ASSERT(Matrix4Impl, 0x8);
+DECOMP_SIZE_ASSERT(Matrix4Data, 0x48);
 
 // OFFSET: LEGO1 0x10002320
-void MatrixImpl::EqualsMatrixData(const Matrix4& p_matrix)
+void Matrix4Impl::EqualsMatrixData(const Matrix4& p_matrix)
 {
 	*m_data = p_matrix;
 }
 
 // OFFSET: LEGO1 0x10002340
-void MatrixImpl::EqualsMatrixImpl(const MatrixImpl* p_other)
+void Matrix4Impl::EqualsMatrixImpl(const Matrix4Impl* p_other)
 {
 	*m_data = *p_other->m_data;
 }
 
 // OFFSET: LEGO1 0x10002360
-void MatrixImpl::AnotherSetData(Matrix4& p_data)
+void Matrix4Impl::AnotherSetData(Matrix4& p_data)
 {
 	m_data = &p_data;
 }
 
 // OFFSET: LEGO1 0x10002370
-void MatrixImpl::SetData(Matrix4& p_data)
+void Matrix4Impl::SetData(Matrix4& p_data)
 {
 	m_data = &p_data;
 }
 
 // OFFSET: LEGO1 0x10002380
-const Matrix4* MatrixImpl::GetData() const
+const Matrix4* Matrix4Impl::GetData() const
 {
 	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002390
-Matrix4* MatrixImpl::GetData()
+Matrix4* Matrix4Impl::GetData()
 {
 	return m_data;
 }
 
 // OFFSET: LEGO1 0x100023a0
-const float* MatrixImpl::Element(int p_row, int p_col) const
+const float* Matrix4Impl::Element(int p_row, int p_col) const
 {
 	return &(*m_data)[p_row][p_col];
 }
 
 // OFFSET: LEGO1 0x100023c0
-float* MatrixImpl::Element(int p_row, int p_col)
+float* Matrix4Impl::Element(int p_row, int p_col)
 {
 	return &(*m_data)[p_row][p_col];
 }
 
 // OFFSET: LEGO1 0x100023e0
-void MatrixImpl::Clear()
+void Matrix4Impl::Clear()
 {
 	memset(m_data, 0, 16 * sizeof(float));
 }
 
 // OFFSET: LEGO1 0x100023f0
-void MatrixImpl::SetIdentity()
+void Matrix4Impl::SetIdentity()
 {
 	Clear();
 	(*m_data)[0][0] = 1.0f;
@@ -75,7 +75,7 @@ void MatrixImpl::SetIdentity()
 }
 
 // OFFSET: LEGO1 0x10002430
-MatrixImpl* MatrixImpl::operator+=(const Matrix4& p_matrix)
+Matrix4Impl* Matrix4Impl::operator+=(const Matrix4& p_matrix)
 {
 	for (int i = 0; i < 16; ++i)
 		((float*) m_data)[i] += ((float*) &p_matrix)[i];
@@ -85,7 +85,7 @@ MatrixImpl* MatrixImpl::operator+=(const Matrix4& p_matrix)
 // Matches but instructions are significantly out of order. Probably not wrong
 // code given that the very similar SetTranslation does match.
 // OFFSET: LEGO1 0x10002460
-void MatrixImpl::TranslateBy(const float* p_x, const float* p_y, const float* p_z)
+void Matrix4Impl::TranslateBy(const float* p_x, const float* p_y, const float* p_z)
 {
 	((float*) m_data)[12] += *p_x;
 	((float*) m_data)[13] += *p_y;
@@ -93,7 +93,7 @@ void MatrixImpl::TranslateBy(const float* p_x, const float* p_y, const float* p_
 }
 
 // OFFSET: LEGO1 0x100024a0
-void MatrixImpl::SetTranslation(const float* p_x, const float* p_y, const float* p_z)
+void Matrix4Impl::SetTranslation(const float* p_x, const float* p_y, const float* p_z)
 {
 	(*m_data)[3][0] = *p_x;
 	(*m_data)[3][1] = *p_y;
@@ -101,7 +101,7 @@ void MatrixImpl::SetTranslation(const float* p_x, const float* p_y, const float*
 }
 
 // OFFSET: LEGO1 0x100024d0
-void MatrixImpl::EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b)
+void Matrix4Impl::EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b)
 {
 	float* cur = (float*) m_data;
 	for (int row = 0; row < 4; ++row) {
@@ -116,7 +116,7 @@ void MatrixImpl::EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b)
 }
 
 // OFFSET: LEGO1 0x10002530
-void MatrixImpl::EqualsMxProduct(const MatrixImpl* p_a, const MatrixImpl* p_b)
+void Matrix4Impl::EqualsMxProduct(const Matrix4Impl* p_a, const Matrix4Impl* p_b)
 {
 	EqualsDataProduct(*p_a->m_data, *p_b->m_data);
 }
@@ -125,7 +125,7 @@ void MatrixImpl::EqualsMxProduct(const MatrixImpl* p_a, const MatrixImpl* p_b)
 // be manually worked out. Included since I at least figured out what it was
 // doing with rotateIndex and what overall operation it's trying to do.
 // OFFSET: LEGO1 0x10002550 STUB
-void MatrixImpl::ToQuaternion(Vector4Impl* p_outQuat)
+void Matrix4Impl::ToQuaternion(Vector4Impl* p_outQuat)
 {
 	/*
 	float trace = m_data[0] + m_data[5] + m_data[10];
@@ -168,19 +168,19 @@ void MatrixImpl::ToQuaternion(Vector4Impl* p_outQuat)
 // No idea what this function is doing and it will be hard to tell until
 // we have a confirmed usage site.
 // OFFSET: LEGO1 0x10002710 STUB
-int MatrixImpl::FUN_10002710(const Vector3Impl* p_vec)
+int Matrix4Impl::FUN_10002710(const Vector3Impl* p_vec)
 {
 	return -1;
 }
 
 // OFFSET: LEGO1 0x10002850
-void MatrixImpl::operator=(const MatrixImpl& p_other)
+void Matrix4Impl::operator=(const Matrix4Impl& p_other)
 {
 	EqualsMatrixImpl(&p_other);
 }
 
 // OFFSET: LEGO1 0x10002860
-void MatrixData::operator=(const MatrixData& p_other)
+void Matrix4Data::operator=(const Matrix4Data& p_other)
 {
 	EqualsMatrixImpl(&p_other);
 }

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -1,7 +1,7 @@
-#ifndef MXMATRIX_H
-#define MXMATRIX_H
+#ifndef MATRIX_H
+#define MATRIX_H
 
-#include "mxvector.h"
+#include "vector.h"
 
 /*
  * A simple array of four Vector4s that can be indexed into.
@@ -9,6 +9,7 @@
 class Matrix4 {
 public:
 	float rows[4][4]; // storage is public for easy access
+
 	inline Matrix4() {}
 	/*
 	Matrix4(const Vector4& x_axis, const Vector4& y_axis, const Vector4& z_axis, const Vector4& position)
@@ -32,12 +33,12 @@ public:
 
 // VTABLE 0x100d4350
 // SIZE 0x8
-class MxMatrix {
+class MatrixImpl {
 public:
-	inline MxMatrix(Matrix4& p_data) : m_data(&p_data) {}
+	inline MatrixImpl(Matrix4& p_data) : m_data(&p_data) {}
 
 	// vtable + 0x00
-	virtual void EqualsMxMatrix(const MxMatrix* p_other);
+	virtual void EqualsMatrixImpl(const MatrixImpl* p_other);
 	virtual void EqualsMatrixData(const Matrix4& p_matrix);
 	virtual void SetData(Matrix4& p_data);
 	virtual void AnotherSetData(Matrix4& p_data);
@@ -51,18 +52,18 @@ public:
 	// vtable + 0x20
 	virtual void Clear();
 	virtual void SetIdentity();
-	virtual void operator=(const MxMatrix& p_other);
-	virtual MxMatrix* operator+=(const Matrix4& p_matrix);
+	virtual void operator=(const MatrixImpl& p_other);
+	virtual MatrixImpl* operator+=(const Matrix4& p_matrix);
 
 	// vtable + 0x30
 	virtual void TranslateBy(const float* p_x, const float* p_y, const float* p_z);
 	virtual void SetTranslation(const float* p_x, const float* p_y, const float* p_z);
-	virtual void EqualsMxProduct(const MxMatrix* p_a, const MxMatrix* p_b);
+	virtual void EqualsMxProduct(const MatrixImpl* p_a, const MatrixImpl* p_b);
 	virtual void EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b);
 
 	// vtable + 0x40
-	virtual void ToQuaternion(MxVector4* p_resultQuat);
-	virtual MxResult FUN_10002710(const MxVector3* p_vec);
+	virtual void ToQuaternion(Vector4Impl* p_resultQuat);
+	virtual int FUN_10002710(const Vector3Impl* p_vec);
 
 	inline float& operator[](size_t idx) { return (*m_data)[idx >> 2][idx & 3]; }
 
@@ -72,18 +73,18 @@ protected:
 
 // VTABLE 0x100d4300
 // SIZE 0x48
-class MxMatrixData : public MxMatrix {
+class MatrixData : public MatrixImpl {
 public:
-	inline MxMatrixData() : MxMatrix(m) {}
-	inline MxMatrixData(MxMatrixData& p_other) : MxMatrix(m) { m = *p_other.m_data; }
+	inline MatrixData() : MatrixImpl(m) {}
+	inline MatrixData(MatrixData& p_other) : MatrixImpl(m) { m = *p_other.m_data; }
 	inline Matrix4& GetMatrix() { return *m_data; }
 
 	// No idea why there's another equals. Maybe to some other type like the
 	// DirectX Retained Mode Matrix type which is also a float* alias?
 	// vtable + 0x44
-	virtual void operator=(const MxMatrixData& p_other);
+	virtual void operator=(const MatrixData& p_other);
 
 	Matrix4 m;
 };
 
-#endif // MXMATRIX_H
+#endif // MATRIX_H

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -33,12 +33,12 @@ public:
 
 // VTABLE 0x100d4350
 // SIZE 0x8
-class MatrixImpl {
+class Matrix4Impl {
 public:
-	inline MatrixImpl(Matrix4& p_data) : m_data(&p_data) {}
+	inline Matrix4Impl(Matrix4& p_data) : m_data(&p_data) {}
 
 	// vtable + 0x00
-	virtual void EqualsMatrixImpl(const MatrixImpl* p_other);
+	virtual void EqualsMatrixImpl(const Matrix4Impl* p_other);
 	virtual void EqualsMatrixData(const Matrix4& p_matrix);
 	virtual void SetData(Matrix4& p_data);
 	virtual void AnotherSetData(Matrix4& p_data);
@@ -52,13 +52,13 @@ public:
 	// vtable + 0x20
 	virtual void Clear();
 	virtual void SetIdentity();
-	virtual void operator=(const MatrixImpl& p_other);
-	virtual MatrixImpl* operator+=(const Matrix4& p_matrix);
+	virtual void operator=(const Matrix4Impl& p_other);
+	virtual Matrix4Impl* operator+=(const Matrix4& p_matrix);
 
 	// vtable + 0x30
 	virtual void TranslateBy(const float* p_x, const float* p_y, const float* p_z);
 	virtual void SetTranslation(const float* p_x, const float* p_y, const float* p_z);
-	virtual void EqualsMxProduct(const MatrixImpl* p_a, const MatrixImpl* p_b);
+	virtual void EqualsMxProduct(const Matrix4Impl* p_a, const Matrix4Impl* p_b);
 	virtual void EqualsDataProduct(const Matrix4& p_a, const Matrix4& p_b);
 
 	// vtable + 0x40
@@ -73,16 +73,16 @@ protected:
 
 // VTABLE 0x100d4300
 // SIZE 0x48
-class MatrixData : public MatrixImpl {
+class Matrix4Data : public Matrix4Impl {
 public:
-	inline MatrixData() : MatrixImpl(m) {}
-	inline MatrixData(MatrixData& p_other) : MatrixImpl(m) { m = *p_other.m_data; }
+	inline Matrix4Data() : Matrix4Impl(m) {}
+	inline Matrix4Data(Matrix4Data& p_other) : Matrix4Impl(m) { m = *p_other.m_data; }
 	inline Matrix4& GetMatrix() { return *m_data; }
 
 	// No idea why there's another equals. Maybe to some other type like the
 	// DirectX Retained Mode Matrix type which is also a float* alias?
 	// vtable + 0x44
-	virtual void operator=(const MatrixData& p_other);
+	virtual void operator=(const Matrix4Data& p_other);
 
 	Matrix4 m;
 };

--- a/LEGO1/realtime/orientableroi.cpp
+++ b/LEGO1/realtime/orientableroi.cpp
@@ -12,26 +12,26 @@ void OrientableROI::VTable0x1c()
 }
 
 // OFFSET: LEGO1 0x100a5930
-void OrientableROI::SetLocalTransform(const MatrixImpl& p_transform)
+void OrientableROI::SetLocalTransform(const Matrix4Impl& p_transform)
 {
-	reinterpret_cast<MatrixImpl&>(m_local2world) = p_transform;
+	reinterpret_cast<Matrix4Impl&>(m_local2world) = p_transform;
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();
 }
 
 // OFFSET: LEGO1 0x100a5960
-void OrientableROI::VTable0x24(const MatrixData& p_transform)
+void OrientableROI::VTable0x24(const Matrix4Data& p_transform)
 {
-	MatrixData l_matrix(m_local2world);
+	Matrix4Data l_matrix(m_local2world);
 	m_local2world.EqualsMxProduct(&p_transform, &l_matrix);
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();
 }
 
 // OFFSET: LEGO1 0x100a59b0
-void OrientableROI::UpdateWorldData(const MatrixData& p_transform)
+void OrientableROI::UpdateWorldData(const Matrix4Data& p_transform)
 {
-	MatrixData l_matrix(m_local2world);
+	Matrix4Data l_matrix(m_local2world);
 	m_local2world.EqualsMxProduct(&l_matrix, &p_transform);
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();

--- a/LEGO1/realtime/orientableroi.cpp
+++ b/LEGO1/realtime/orientableroi.cpp
@@ -12,26 +12,26 @@ void OrientableROI::VTable0x1c()
 }
 
 // OFFSET: LEGO1 0x100a5930
-void OrientableROI::SetLocalTransform(const MxMatrix& p_transform)
+void OrientableROI::SetLocalTransform(const MatrixImpl& p_transform)
 {
-	reinterpret_cast<MxMatrix&>(m_local2world) = p_transform;
+	reinterpret_cast<MatrixImpl&>(m_local2world) = p_transform;
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();
 }
 
 // OFFSET: LEGO1 0x100a5960
-void OrientableROI::VTable0x24(const MxMatrixData& p_transform)
+void OrientableROI::VTable0x24(const MatrixData& p_transform)
 {
-	MxMatrixData l_matrix(m_local2world);
+	MatrixData l_matrix(m_local2world);
 	m_local2world.EqualsMxProduct(&p_transform, &l_matrix);
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();
 }
 
 // OFFSET: LEGO1 0x100a59b0
-void OrientableROI::UpdateWorldData(const MxMatrixData& p_transform)
+void OrientableROI::UpdateWorldData(const MatrixData& p_transform)
 {
-	MxMatrixData l_matrix(m_local2world);
+	MatrixData l_matrix(m_local2world);
 	m_local2world.EqualsMxProduct(&l_matrix, &p_transform);
 	UpdateWorldBoundingVolumes();
 	UpdateWorldVelocity();
@@ -54,11 +54,13 @@ const Vector3& OrientableROI::GetWorldVelocity() const
 {
 	return (Vector3&) *m_world_velocity.GetData();
 }
+
 // OFFSET: LEGO1 0x100a5d90
 const BoundingBox& OrientableROI::GetWorldBoundingBox() const
 {
 	return m_world_bounding_box;
 }
+
 // OFFSET: LEGO1 0x100a5da0
 const BoundingSphere& OrientableROI::GetWorldBoundingSphere() const
 {

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -31,14 +31,14 @@ protected:
 public:
 	virtual void VTable0x1c();
 	// vtable + 0x20
-	virtual void SetLocalTransform(const MatrixImpl& p_transform);
-	virtual void VTable0x24(const MatrixData& p_transform);
-	virtual void UpdateWorldData(const MatrixData& p_transform);
+	virtual void SetLocalTransform(const Matrix4Impl& p_transform);
+	virtual void VTable0x24(const Matrix4Data& p_transform);
+	virtual void UpdateWorldData(const Matrix4Data& p_transform);
 	virtual void UpdateWorldVelocity();
 
 protected:
 	char m_unkc;
-	MatrixData m_local2world;               // 0x10
+	Matrix4Data m_local2world;              // 0x10
 	BoundingBox m_world_bounding_box;       // 0x58
 	BoundingSphere m_world_bounding_sphere; // 0xa8
 	Vector3Data m_world_velocity;           // 0xc0

--- a/LEGO1/realtime/orientableroi.h
+++ b/LEGO1/realtime/orientableroi.h
@@ -1,7 +1,7 @@
 #ifndef ORIENTABLEROI_H
 #define ORIENTABLEROI_H
 
-#include "mxmatrix.h"
+#include "matrix.h"
 #include "roi.h"
 
 class OrientableROI : public ROI {
@@ -31,19 +31,19 @@ protected:
 public:
 	virtual void VTable0x1c();
 	// vtable + 0x20
-	virtual void SetLocalTransform(const MxMatrix& p_transform);
-	virtual void VTable0x24(const MxMatrixData& p_transform);
-	virtual void UpdateWorldData(const MxMatrixData& p_transform);
+	virtual void SetLocalTransform(const MatrixImpl& p_transform);
+	virtual void VTable0x24(const MatrixData& p_transform);
+	virtual void UpdateWorldData(const MatrixData& p_transform);
 	virtual void UpdateWorldVelocity();
 
 protected:
 	char m_unkc;
-	MxMatrixData m_local2world;             // 0x10
+	MatrixData m_local2world;               // 0x10
 	BoundingBox m_world_bounding_box;       // 0x58
 	BoundingSphere m_world_bounding_sphere; // 0xa8
-	MxVector3Data m_world_velocity;         // 0xc0
-	MxU32 m_unkd4;
-	MxU32 m_unkd8;
+	Vector3Data m_world_velocity;           // 0xc0
+	unsigned int m_unkd4;
+	unsigned int m_unkd8;
 };
 
 #endif // ORIENTABLEROI_H

--- a/LEGO1/realtime/realtime.cpp
+++ b/LEGO1/realtime/realtime.cpp
@@ -5,7 +5,7 @@ void CalcLocalTransform(
 	const Vector3Impl& p_posVec,
 	const Vector3Impl& p_dirVec,
 	const Vector3Impl& p_upVec,
-	MatrixImpl& p_outMatrix
+	Matrix4Impl& p_outMatrix
 )
 {
 	float x_axis[3], y_axis[3], z_axis[3];

--- a/LEGO1/realtime/realtime.cpp
+++ b/LEGO1/realtime/realtime.cpp
@@ -2,19 +2,19 @@
 
 // OFFSET: LEGO1 0x100a5b40
 void CalcLocalTransform(
-	const MxVector3& p_posVec,
-	const MxVector3& p_dirVec,
-	const MxVector3& p_upVec,
-	MxMatrix& p_outMatrix
+	const Vector3Impl& p_posVec,
+	const Vector3Impl& p_dirVec,
+	const Vector3Impl& p_upVec,
+	MatrixImpl& p_outMatrix
 )
 {
-	MxFloat x_axis[3], y_axis[3], z_axis[3];
+	float x_axis[3], y_axis[3], z_axis[3];
 
 	// This is an unrolled version of the "NORMVEC3" macro,
 	// used here to apply a silly hack to get a 100% match
 	{
-		const MxFloat dirVec1Operation = (p_dirVec)[1] * (p_dirVec)[1];
-		MxDouble len = sqrt(((p_dirVec)[0] * (p_dirVec)[0] + dirVec1Operation + (p_dirVec)[2] * (p_dirVec)[2]));
+		const float dirVec1Operation = (p_dirVec)[1] * (p_dirVec)[1];
+		double len = sqrt(((p_dirVec)[0] * (p_dirVec)[0] + dirVec1Operation + (p_dirVec)[2] * (p_dirVec)[2]));
 		((z_axis)[0] = (p_dirVec)[0] / (len), (z_axis)[1] = (p_dirVec)[1] / (len), (z_axis)[2] = (p_dirVec)[2] / (len));
 	}
 
@@ -24,8 +24,8 @@ void CalcLocalTransform(
 
 	// Exact same thing as pointed out by the above comment
 	{
-		const MxFloat axis2Operation = (x_axis)[2] * (x_axis)[2];
-		MxDouble len = sqrt(((x_axis)[0] * (x_axis)[0] + axis2Operation + (x_axis)[1] * (x_axis)[1]));
+		const float axis2Operation = (x_axis)[2] * (x_axis)[2];
+		double len = sqrt(((x_axis)[0] * (x_axis)[0] + axis2Operation + (x_axis)[1] * (x_axis)[1]));
 		((x_axis)[0] = (x_axis)[0] / (len), (x_axis)[1] = (x_axis)[1] / (len), (x_axis)[2] = (x_axis)[2] / (len));
 	}
 
@@ -33,8 +33,8 @@ void CalcLocalTransform(
 
 	// Again, the same thing
 	{
-		const MxFloat axis2Operation = (y_axis)[2] * (y_axis)[2];
-		MxDouble len = sqrt(((y_axis)[0] * (y_axis)[0] + axis2Operation + (y_axis)[1] * (y_axis)[1]));
+		const float axis2Operation = (y_axis)[2] * (y_axis)[2];
+		double len = sqrt(((y_axis)[0] * (y_axis)[0] + axis2Operation + (y_axis)[1] * (y_axis)[1]));
 		((y_axis)[0] = (y_axis)[0] / (len), (y_axis)[1] = (y_axis)[1] / (len), (y_axis)[2] = (y_axis)[2] / (len));
 	}
 

--- a/LEGO1/realtime/realtime.h
+++ b/LEGO1/realtime/realtime.h
@@ -13,7 +13,7 @@ void CalcLocalTransform(
 	const Vector3Impl& p_posVec,
 	const Vector3Impl& p_dirVec,
 	const Vector3Impl& p_upVec,
-	MatrixImpl& p_outMatrix
+	Matrix4Impl& p_outMatrix
 );
 
 #endif // REALTIME_H

--- a/LEGO1/realtime/realtime.h
+++ b/LEGO1/realtime/realtime.h
@@ -1,19 +1,19 @@
 #ifndef REALTIME_H
 #define REALTIME_H
 
-#include "mxmatrix.h"
+#include "matrix.h"
 
 #define NORMVEC3(dst, src)                                                                                             \
 	{                                                                                                                  \
-		MxDouble len = sqrt(NORMSQRD3(src));                                                                           \
+		double len = sqrt(NORMSQRD3(src));                                                                             \
 		VDS3(dst, src, len);                                                                                           \
 	}
 
 void CalcLocalTransform(
-	const MxVector3& p_posVec,
-	const MxVector3& p_dirVec,
-	const MxVector3& p_upVec,
-	MxMatrix& p_outMatrix
+	const Vector3Impl& p_posVec,
+	const Vector3Impl& p_dirVec,
+	const Vector3Impl& p_upVec,
+	MatrixImpl& p_outMatrix
 );
 
 #endif // REALTIME_H

--- a/LEGO1/realtime/roi.h
+++ b/LEGO1/realtime/roi.h
@@ -5,23 +5,23 @@
 #include "../mxstl.h"
 #include "../realtime/realtime.h"
 #include "lodlist.h"
-#include "mxvector.h"
+#include "vector.h"
 
 /*
  * A simple bounding box object with Min and Max accessor methods.
  */
 class BoundingBox {
 public:
-	const MxVector3Data& Min() const { return min; }
-	MxVector3Data& Min() { return min; }
-	const MxVector3Data& Max() const { return max; }
-	MxVector3Data& Max() { return max; }
+	const Vector3Data& Min() const { return min; }
+	Vector3Data& Min() { return min; }
+	const Vector3Data& Max() const { return max; }
+	Vector3Data& Max() { return max; }
 
 private:
-	MxVector3Data min;
-	MxVector3Data max;
-	MxVector3Data m_unk28;
-	MxVector3Data m_unk3c;
+	Vector3Data min;
+	Vector3Data max;
+	Vector3Data m_unk28;
+	Vector3Data m_unk3c;
 };
 
 /*
@@ -29,13 +29,13 @@ private:
  */
 class BoundingSphere {
 public:
-	const MxVector3Data& Center() const { return center; }
-	MxVector3Data& Center() { return center; }
+	const Vector3Data& Center() const { return center; }
+	Vector3Data& Center() { return center; }
 	const float& Radius() const { return radius; }
 	float& Radius() { return radius; }
 
 private:
-	MxVector3Data center;
+	Vector3Data center;
 	float radius;
 };
 

--- a/LEGO1/realtime/vector.cpp
+++ b/LEGO1/realtime/vector.cpp
@@ -1,183 +1,183 @@
 
-#include "mxvector.h"
+#include "vector.h"
 
 #include "../decomp.h"
 
 #include <math.h>
 #include <memory.h>
 
-DECOMP_SIZE_ASSERT(MxVector2, 0x8);
-DECOMP_SIZE_ASSERT(MxVector3, 0x8);
-DECOMP_SIZE_ASSERT(MxVector4, 0x8);
-DECOMP_SIZE_ASSERT(MxVector3Data, 0x14);
-DECOMP_SIZE_ASSERT(MxVector4Data, 0x18);
+DECOMP_SIZE_ASSERT(Vector2Impl, 0x8);
+DECOMP_SIZE_ASSERT(Vector3Impl, 0x8);
+DECOMP_SIZE_ASSERT(Vector4Impl, 0x8);
+DECOMP_SIZE_ASSERT(Vector3Data, 0x14);
+DECOMP_SIZE_ASSERT(Vector4Data, 0x18);
 
 // OFFSET: LEGO1 0x100020a0
-const float* MxVector2::GetData() const
+const float* Vector2Impl::GetData() const
 {
 	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002090
-float* MxVector2::GetData()
+float* Vector2Impl::GetData()
 {
 	return m_data;
 }
 
 // OFFSET: LEGO1 0x10002130
-float MxVector2::Dot(MxVector2* p_a, float* p_b) const
+float Vector2Impl::Dot(Vector2Impl* p_a, float* p_b) const
 {
 	return DotImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x10002110
-float MxVector2::Dot(float* p_a, MxVector2* p_b) const
+float Vector2Impl::Dot(float* p_a, Vector2Impl* p_b) const
 {
 	return DotImpl(p_a, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100020f0
-float MxVector2::Dot(MxVector2* p_a, MxVector2* p_b) const
+float Vector2Impl::Dot(Vector2Impl* p_a, Vector2Impl* p_b) const
 {
 	return DotImpl(p_a->m_data, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100020d0
-float MxVector2::Dot(float* p_a, float* p_b) const
+float Vector2Impl::Dot(float* p_a, float* p_b) const
 {
 	return DotImpl(p_a, p_b);
 }
 
 // OFFSET: LEGO1 0x10002160
-MxResult MxVector2::Unitize()
+int Vector2Impl::Unitize()
 {
 	float sq = LenSquared();
 	if (sq > 0.0f) {
 		float root = sqrt(sq);
 		if (root > 0) {
 			DivScalarImpl(&root);
-			return SUCCESS;
+			return 0;
 		}
 	}
-	return FAILURE;
+	return -1;
 }
 
 // OFFSET: LEGO1 0x100021e0
-void MxVector2::AddVector(MxVector2* p_other)
+void Vector2Impl::AddVector(Vector2Impl* p_other)
 {
 	AddVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x100021d0
-void MxVector2::AddVector(float* p_other)
+void Vector2Impl::AddVector(float* p_other)
 {
 	AddVectorImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x100021c0
-void MxVector2::AddScalar(float p_value)
+void Vector2Impl::AddScalar(float p_value)
 {
 	AddScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x10002200
-void MxVector2::SubVector(MxVector2* p_other)
+void Vector2Impl::SubVector(Vector2Impl* p_other)
 {
 	SubVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x100021f0
-void MxVector2::SubVector(float* p_other)
+void Vector2Impl::SubVector(float* p_other)
 {
 	SubVectorImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x10002230
-void MxVector2::MullScalar(float* p_value)
+void Vector2Impl::MullScalar(float* p_value)
 {
 	MullScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x10002220
-void MxVector2::MullVector(MxVector2* p_other)
+void Vector2Impl::MullVector(Vector2Impl* p_other)
 {
 	MullVectorImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x10002210
-void MxVector2::MullVector(float* p_other)
+void Vector2Impl::MullVector(float* p_other)
 {
 	MullVectorImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x10002240
-void MxVector2::DivScalar(float* p_value)
+void Vector2Impl::DivScalar(float* p_value)
 {
 	DivScalarImpl(p_value);
 }
 
 // OFFSET: LEGO1 0x10002260
-void MxVector2::SetVector(MxVector2* p_other)
+void Vector2Impl::SetVector(Vector2Impl* p_other)
 {
 	EqualsImpl(p_other->m_data);
 }
 
 // OFFSET: LEGO1 0x10002250
-void MxVector2::SetVector(float* p_other)
+void Vector2Impl::SetVector(float* p_other)
 {
 	EqualsImpl(p_other);
 }
 
 // OFFSET: LEGO1 0x10001fa0
-void MxVector2::AddScalarImpl(float p_value)
+void Vector2Impl::AddScalarImpl(float p_value)
 {
 	m_data[0] += p_value;
 	m_data[1] += p_value;
 }
 
 // OFFSET: LEGO1 0x10001f80
-void MxVector2::AddVectorImpl(float* p_value)
+void Vector2Impl::AddVectorImpl(float* p_value)
 {
 	m_data[0] += p_value[0];
 	m_data[1] += p_value[1];
 }
 
 // OFFSET: LEGO1 0x10001fc0
-void MxVector2::SubVectorImpl(float* p_value)
+void Vector2Impl::SubVectorImpl(float* p_value)
 {
 	m_data[0] -= p_value[0];
 	m_data[1] -= p_value[1];
 }
 
 // OFFSET: LEGO1 0x10002000
-void MxVector2::MullScalarImpl(float* p_value)
+void Vector2Impl::MullScalarImpl(float* p_value)
 {
 	m_data[0] *= *p_value;
 	m_data[1] *= *p_value;
 }
 
 // OFFSET: LEGO1 0x10001fe0
-void MxVector2::MullVectorImpl(float* p_value)
+void Vector2Impl::MullVectorImpl(float* p_value)
 {
 	m_data[0] *= p_value[0];
 	m_data[1] *= p_value[1];
 }
 
 // OFFSET: LEGO1 0x10002020
-void MxVector2::DivScalarImpl(float* p_value)
+void Vector2Impl::DivScalarImpl(float* p_value)
 {
 	m_data[0] /= *p_value;
 	m_data[1] /= *p_value;
 }
 
 // OFFSET: LEGO1 0x10002040
-float MxVector2::DotImpl(float* p_a, float* p_b) const
+float Vector2Impl::DotImpl(float* p_a, float* p_b) const
 {
 	return p_b[0] * p_a[0] + p_b[1] * p_a[1];
 }
 
 // OFFSET: LEGO1 0x10002070
-void MxVector2::EqualsImpl(float* p_data)
+void Vector2Impl::EqualsImpl(float* p_data)
 {
 	float* vec = m_data;
 	vec[0] = p_data[0];
@@ -185,7 +185,7 @@ void MxVector2::EqualsImpl(float* p_data)
 }
 
 // OFFSET: LEGO1 0x100020b0
-void MxVector2::Clear()
+void Vector2Impl::Clear()
 {
 	float* vec = m_data;
 	vec[0] = 0.0f;
@@ -193,13 +193,13 @@ void MxVector2::Clear()
 }
 
 // OFFSET: LEGO1 0x10002150
-float MxVector2::LenSquared() const
+float Vector2Impl::LenSquared() const
 {
 	return m_data[0] * m_data[0] + m_data[1] * m_data[1];
 }
 
 // OFFSET: LEGO1 0x10003a90
-void MxVector3::AddScalarImpl(float p_value)
+void Vector3Impl::AddScalarImpl(float p_value)
 {
 	m_data[0] += p_value;
 	m_data[1] += p_value;
@@ -207,7 +207,7 @@ void MxVector3::AddScalarImpl(float p_value)
 }
 
 // OFFSET: LEGO1 0x10003a60
-void MxVector3::AddVectorImpl(float* p_value)
+void Vector3Impl::AddVectorImpl(float* p_value)
 {
 	m_data[0] += p_value[0];
 	m_data[1] += p_value[1];
@@ -215,7 +215,7 @@ void MxVector3::AddVectorImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10003ac0
-void MxVector3::SubVectorImpl(float* p_value)
+void Vector3Impl::SubVectorImpl(float* p_value)
 {
 	m_data[0] -= p_value[0];
 	m_data[1] -= p_value[1];
@@ -223,7 +223,7 @@ void MxVector3::SubVectorImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10003b20
-void MxVector3::MullScalarImpl(float* p_value)
+void Vector3Impl::MullScalarImpl(float* p_value)
 {
 	m_data[0] *= *p_value;
 	m_data[1] *= *p_value;
@@ -231,7 +231,7 @@ void MxVector3::MullScalarImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10003af0
-void MxVector3::MullVectorImpl(float* p_value)
+void Vector3Impl::MullVectorImpl(float* p_value)
 {
 	m_data[0] *= p_value[0];
 	m_data[1] *= p_value[1];
@@ -239,7 +239,7 @@ void MxVector3::MullVectorImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10003b50
-void MxVector3::DivScalarImpl(float* p_value)
+void Vector3Impl::DivScalarImpl(float* p_value)
 {
 	m_data[0] /= *p_value;
 	m_data[1] /= *p_value;
@@ -247,13 +247,13 @@ void MxVector3::DivScalarImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10003b80
-float MxVector3::DotImpl(float* p_a, float* p_b) const
+float Vector3Impl::DotImpl(float* p_a, float* p_b) const
 {
 	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + p_a[1] * p_b[1];
 }
 
 // OFFSET: LEGO1 0x10003ba0
-void MxVector3::EqualsImpl(float* p_data)
+void Vector3Impl::EqualsImpl(float* p_data)
 {
 	float* vec = m_data;
 	vec[0] = p_data[0];
@@ -262,7 +262,7 @@ void MxVector3::EqualsImpl(float* p_data)
 }
 
 // OFFSET: LEGO1 0x10003bc0
-void MxVector3::Clear()
+void Vector3Impl::Clear()
 {
 	float* vec = m_data;
 	vec[0] = 0.0f;
@@ -271,13 +271,13 @@ void MxVector3::Clear()
 }
 
 // OFFSET: LEGO1 0x10003bd0
-float MxVector3::LenSquared() const
+float Vector3Impl::LenSquared() const
 {
 	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2];
 }
 
 // OFFSET: LEGO1 0x10002270
-void MxVector3::EqualsCrossImpl(float* p_a, float* p_b)
+void Vector3Impl::EqualsCrossImpl(float* p_a, float* p_b)
 {
 	m_data[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
 	m_data[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
@@ -285,25 +285,25 @@ void MxVector3::EqualsCrossImpl(float* p_a, float* p_b)
 }
 
 // OFFSET: LEGO1 0x10002300
-void MxVector3::EqualsCross(float* p_a, MxVector3* p_b)
+void Vector3Impl::EqualsCross(float* p_a, Vector3Impl* p_b)
 {
 	EqualsCrossImpl(p_a, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x100022e0
-void MxVector3::EqualsCross(MxVector3* p_a, float* p_b)
+void Vector3Impl::EqualsCross(Vector3Impl* p_a, float* p_b)
 {
 	EqualsCrossImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x100022c0
-void MxVector3::EqualsCross(MxVector3* p_a, MxVector3* p_b)
+void Vector3Impl::EqualsCross(Vector3Impl* p_a, Vector3Impl* p_b)
 {
 	EqualsCrossImpl(p_a->m_data, p_b->m_data);
 }
 
 // OFFSET: LEGO1 0x10003bf0
-void MxVector3::EqualsScalar(float* p_value)
+void Vector3Impl::EqualsScalar(float* p_value)
 {
 	m_data[0] = *p_value;
 	m_data[1] = *p_value;
@@ -311,7 +311,7 @@ void MxVector3::EqualsScalar(float* p_value)
 }
 
 // OFFSET: LEGO1 0x100028b0
-void MxVector4::AddScalarImpl(float p_value)
+void Vector4Impl::AddScalarImpl(float p_value)
 {
 	m_data[0] += p_value;
 	m_data[1] += p_value;
@@ -320,7 +320,7 @@ void MxVector4::AddScalarImpl(float p_value)
 }
 
 // OFFSET: LEGO1 0x10002870
-void MxVector4::AddVectorImpl(float* p_value)
+void Vector4Impl::AddVectorImpl(float* p_value)
 {
 	m_data[0] += p_value[0];
 	m_data[1] += p_value[1];
@@ -329,7 +329,7 @@ void MxVector4::AddVectorImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x100028f0
-void MxVector4::SubVectorImpl(float* p_value)
+void Vector4Impl::SubVectorImpl(float* p_value)
 {
 	m_data[0] -= p_value[0];
 	m_data[1] -= p_value[1];
@@ -338,7 +338,7 @@ void MxVector4::SubVectorImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10002970
-void MxVector4::MullScalarImpl(float* p_value)
+void Vector4Impl::MullScalarImpl(float* p_value)
 {
 	m_data[0] *= *p_value;
 	m_data[1] *= *p_value;
@@ -347,7 +347,7 @@ void MxVector4::MullScalarImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10002930
-void MxVector4::MullVectorImpl(float* p_value)
+void Vector4Impl::MullVectorImpl(float* p_value)
 {
 	m_data[0] *= p_value[0];
 	m_data[1] *= p_value[1];
@@ -356,7 +356,7 @@ void MxVector4::MullVectorImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x100029b0
-void MxVector4::DivScalarImpl(float* p_value)
+void Vector4Impl::DivScalarImpl(float* p_value)
 {
 	m_data[0] /= *p_value;
 	m_data[1] /= *p_value;
@@ -365,13 +365,13 @@ void MxVector4::DivScalarImpl(float* p_value)
 }
 
 // OFFSET: LEGO1 0x100029f0
-float MxVector4::DotImpl(float* p_a, float* p_b) const
+float Vector4Impl::DotImpl(float* p_a, float* p_b) const
 {
 	return p_a[0] * p_b[0] + p_a[2] * p_b[2] + (p_a[1] * p_b[1] + p_a[3] * p_b[3]);
 }
 
 // OFFSET: LEGO1 0x10002a20
-void MxVector4::EqualsImpl(float* p_data)
+void Vector4Impl::EqualsImpl(float* p_data)
 {
 	float* vec = m_data;
 	vec[0] = p_data[0];
@@ -381,7 +381,7 @@ void MxVector4::EqualsImpl(float* p_data)
 }
 
 // OFFSET: LEGO1 0x10002b00
-void MxVector4::Clear()
+void Vector4Impl::Clear()
 {
 	float* vec = m_data;
 	vec[0] = 0.0f;
@@ -391,13 +391,13 @@ void MxVector4::Clear()
 }
 
 // OFFSET: LEGO1 0x10002b20
-float MxVector4::LenSquared() const
+float Vector4Impl::LenSquared() const
 {
 	return m_data[1] * m_data[1] + m_data[0] * m_data[0] + m_data[2] * m_data[2] + m_data[3] * m_data[3];
 }
 
 // OFFSET: LEGO1 0x10002b40
-void MxVector4::EqualsScalar(float* p_value)
+void Vector4Impl::EqualsScalar(float* p_value)
 {
 	m_data[0] = *p_value;
 	m_data[1] = *p_value;
@@ -406,13 +406,13 @@ void MxVector4::EqualsScalar(float* p_value)
 }
 
 // OFFSET: LEGO1 0x10002ae0
-void MxVector4::SetMatrixProduct(MxVector4* p_a, float* p_b)
+void Vector4Impl::SetMatrixProduct(Vector4Impl* p_a, float* p_b)
 {
 	SetMatrixProductImpl(p_a->m_data, p_b);
 }
 
 // OFFSET: LEGO1 0x10002a40
-void MxVector4::SetMatrixProductImpl(float* p_vec, float* p_mat)
+void Vector4Impl::SetMatrixProductImpl(float* p_vec, float* p_mat)
 {
 	m_data[0] = p_vec[0] * p_mat[0] + p_vec[1] * p_mat[4] + p_vec[2] * p_mat[8] + p_vec[3] * p_mat[12];
 	m_data[1] = p_vec[0] * p_mat[1] + p_vec[1] * p_mat[5] + p_vec[2] * p_mat[9] + p_vec[4] * p_mat[13];
@@ -423,7 +423,7 @@ void MxVector4::SetMatrixProductImpl(float* p_vec, float* p_mat)
 // Note close yet, included because I'm at least confident I know what operation
 // it's trying to do.
 // OFFSET: LEGO1 0x10002b70 STUB
-MxResult MxVector4::NormalizeQuaternion()
+int Vector4Impl::NormalizeQuaternion()
 {
 	float* v = m_data;
 	float magnitude = v[1] * v[1] + v[2] * v[2] + v[0] * v[0];
@@ -435,16 +435,16 @@ MxResult MxVector4::NormalizeQuaternion()
 		v[0] *= magnitude;
 		v[1] *= magnitude;
 		v[2] *= magnitude;
-		return SUCCESS;
+		return 0;
 	}
-	return FAILURE;
+	return -1;
 }
 
 // OFFSET: LEGO1 0x10002bf0
-void MxVector4::UnknownQuaternionOp(MxVector4* p_a, MxVector4* p_b)
+void Vector4Impl::UnknownQuaternionOp(Vector4Impl* p_a, Vector4Impl* p_b)
 {
-	MxFloat* bDat = p_b->m_data;
-	MxFloat* aDat = p_a->m_data;
+	float* bDat = p_b->m_data;
+	float* aDat = p_a->m_data;
 
 	this->m_data[3] = aDat[3] * bDat[3] - (bDat[0] * aDat[0] + aDat[2] * bDat[2] + aDat[1] * aDat[1]);
 	this->m_data[0] = bDat[2] * aDat[1] - bDat[1] * aDat[2];

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -1,7 +1,5 @@
-#ifndef MXVECTOR_H
-#define MXVECTOR_H
-
-#include "../mxtypes.h"
+#ifndef VECTOR_H
+#define VECTOR_H
 
 #include <vec.h>
 
@@ -11,6 +9,7 @@
 class Vector3 {
 public:
 	float elements[3]; // storage is public for easy access
+
 	Vector3() {}
 	Vector3(float x, float y, float z)
 	{
@@ -18,12 +17,14 @@ public:
 		elements[1] = y;
 		elements[2] = z;
 	}
+
 	Vector3(const float v[3])
 	{
 		elements[0] = v[0];
 		elements[1] = v[1];
 		elements[2] = v[2];
 	}
+
 	const float& operator[](long i) const { return elements[i]; }
 	float& operator[](long i) { return elements[i]; }
 };
@@ -34,6 +35,7 @@ public:
 struct Vector4 {
 public:
 	float elements[4]; // storage is public for easy access
+
 	inline Vector4() {}
 	Vector4(float x, float y, float z, float w)
 	{
@@ -49,16 +51,17 @@ public:
 		elements[2] = v[2];
 		elements[3] = v[3];
 	}
+
 	const float& operator[](long i) const { return elements[i]; }
 	float& operator[](long i) { return elements[i]; }
 };
 
 // VTABLE 0x100d4288
 // SIZE 0x8
-class MxVector2 {
+class Vector2Impl {
 public:
 	// OFFSET: LEGO1 0x1000c0f0
-	inline MxVector2(float* p_data) { this->SetData(p_data); }
+	inline Vector2Impl(float* p_data) { this->SetData(p_data); }
 
 	// vtable + 0x00 (no virtual destructor)
 	virtual void AddScalarImpl(float p_value) = 0;
@@ -81,32 +84,32 @@ public:
 	virtual void Clear() = 0;
 
 	// vtable + 0x30
-	virtual float Dot(MxVector2* p_a, float* p_b) const;
-	virtual float Dot(float* p_a, MxVector2* p_b) const;
-	virtual float Dot(MxVector2* p_a, MxVector2* p_b) const;
+	virtual float Dot(Vector2Impl* p_a, float* p_b) const;
+	virtual float Dot(float* p_a, Vector2Impl* p_b) const;
+	virtual float Dot(Vector2Impl* p_a, Vector2Impl* p_b) const;
 	virtual float Dot(float* p_a, float* p_b) const;
 
 	// vtable + 0x40
 	virtual float LenSquared() const = 0;
-	virtual MxResult Unitize();
+	virtual int Unitize();
 
 	// vtable + 0x48
-	virtual void AddVector(MxVector2* p_other);
+	virtual void AddVector(Vector2Impl* p_other);
 	virtual void AddVector(float* p_other);
 	virtual void AddScalar(float p_value);
 
 	// vtable + 0x54
-	virtual void SubVector(MxVector2* p_other);
+	virtual void SubVector(Vector2Impl* p_other);
 	virtual void SubVector(float* p_other);
 
 	// vtable + 0x5C
 	virtual void MullScalar(float* p_value);
-	virtual void MullVector(MxVector2* p_other);
+	virtual void MullVector(Vector2Impl* p_other);
 	virtual void MullVector(float* p_other);
 	virtual void DivScalar(float* p_value);
 
 	// vtable + 0x6C
-	virtual void SetVector(MxVector2* p_other);
+	virtual void SetVector(Vector2Impl* p_other);
 	virtual void SetVector(float* p_other);
 
 	inline float& operator[](size_t idx) { return m_data[idx]; }
@@ -118,9 +121,9 @@ protected:
 
 // VTABLE 0x100d4518
 // SIZE 0x8
-class MxVector3 : public MxVector2 {
+class Vector3Impl : public Vector2Impl {
 public:
-	inline MxVector3(float* p_data) : MxVector2(p_data) {}
+	inline Vector3Impl(float* p_data) : Vector2Impl(p_data) {}
 
 	void AddScalarImpl(float p_value);
 
@@ -140,9 +143,9 @@ public:
 
 	// vtable + 0x74
 	virtual void EqualsCrossImpl(float* p_a, float* p_b);
-	virtual void EqualsCross(float* p_a, MxVector3* p_b);
-	virtual void EqualsCross(MxVector3* p_a, float* p_b);
-	virtual void EqualsCross(MxVector3* p_a, MxVector3* p_b);
+	virtual void EqualsCross(float* p_a, Vector3Impl* p_b);
+	virtual void EqualsCross(Vector3Impl* p_a, float* p_b);
+	virtual void EqualsCross(Vector3Impl* p_a, Vector3Impl* p_b);
 	virtual void EqualsScalar(float* p_value);
 
 	inline void Fill(float p_value) { EqualsScalar(&p_value); }
@@ -150,9 +153,9 @@ public:
 
 // VTABLE 0x100d45a0
 // SIZE 0x8
-class MxVector4 : public MxVector3 {
+class Vector4Impl : public Vector3Impl {
 public:
-	inline MxVector4(float* p_data) : MxVector3(p_data) {}
+	inline Vector4Impl(float* p_data) : Vector3Impl(p_data) {}
 
 	void AddScalarImpl(float p_value);
 
@@ -173,18 +176,18 @@ public:
 	void EqualsScalar(float* p_value);
 
 	// vtable + 0x84
-	virtual void SetMatrixProduct(MxVector4* p_a, float* p_b);
+	virtual void SetMatrixProduct(Vector4Impl* p_a, float* p_b);
 	virtual void SetMatrixProductImpl(float* p_vec, float* p_mat);
-	virtual MxResult NormalizeQuaternion();
-	virtual void UnknownQuaternionOp(MxVector4* p_a, MxVector4* p_b);
+	virtual int NormalizeQuaternion();
+	virtual void UnknownQuaternionOp(Vector4Impl* p_a, Vector4Impl* p_b);
 };
 
 // VTABLE 0x100d4488
 // SIZE 0x14
-class MxVector3Data : public MxVector3 {
+class Vector3Data : public Vector3Impl {
 public:
-	inline MxVector3Data() : MxVector3(storage) {}
-	inline MxVector3Data(float p_x, float p_y, float p_z) : MxVector3(storage), x(p_x), y(p_y), z(p_z) {}
+	inline Vector3Data() : Vector3Impl(storage) {}
+	inline Vector3Data(float p_x, float p_y, float p_z) : Vector3Impl(storage), x(p_x), y(p_y), z(p_z) {}
 
 	union {
 		float storage[3];
@@ -195,7 +198,7 @@ public:
 		};
 	};
 
-	void CopyFrom(MxVector3Data& p_other)
+	void CopyFrom(Vector3Data& p_other)
 	{
 		EqualsImpl(p_other.m_data);
 
@@ -208,9 +211,9 @@ public:
 
 // VTABLE 0x100d41e8
 // SIZE 0x18
-class MxVector4Data : public MxVector4 {
+class Vector4Data : public Vector4Impl {
 public:
-	inline MxVector4Data() : MxVector4(storage) {}
+	inline Vector4Data() : Vector4Impl(storage) {}
 	union {
 		float storage[4];
 		struct {
@@ -222,4 +225,4 @@ public:
 	};
 };
 
-#endif // MXVECTOR_H
+#endif // VECTOR_H

--- a/LEGO1/viewmanager/viewlodlist.h
+++ b/LEGO1/viewmanager/viewlodlist.h
@@ -2,9 +2,9 @@
 #define VIEWLODLIST_H
 
 #include "../compat.h"
-#include "../mxtypes.h"
-#include "../realtime/LODList.h"
+#include "../realtime/lodlist.h"
 #include "assert.h"
+
 #pragma warning(disable : 4786)
 
 class ViewLOD;
@@ -44,7 +44,7 @@ private:
 // ??? for now, until we have symbol management
 typedef const char* ROIName;
 struct ROINameComparator {
-	MxBool operator()(const ROIName& rName1, const ROIName& rName2) const
+	bool operator()(const ROIName& rName1, const ROIName& rName2) const
 	{
 		return strcmp((const char*) rName1, (const char*) rName2) > 0;
 	}

--- a/LEGO1/viewmanager/viewroi.cpp
+++ b/LEGO1/viewmanager/viewroi.cpp
@@ -23,7 +23,7 @@ Tgl::Group* ViewROI::GetGeometry()
 }
 
 // OFFSET: LEGO1 0x100a9ee0
-void ViewROI::UpdateWorldData(const MxMatrixData& parent2world)
+void ViewROI::UpdateWorldData(const MatrixData& parent2world)
 {
 	OrientableROI::UpdateWorldData(parent2world);
 	if (geometry) {

--- a/LEGO1/viewmanager/viewroi.cpp
+++ b/LEGO1/viewmanager/viewroi.cpp
@@ -23,7 +23,7 @@ Tgl::Group* ViewROI::GetGeometry()
 }
 
 // OFFSET: LEGO1 0x100a9ee0
-void ViewROI::UpdateWorldData(const MatrixData& parent2world)
+void ViewROI::UpdateWorldData(const Matrix4Data& parent2world)
 {
 	OrientableROI::UpdateWorldData(parent2world);
 	if (geometry) {

--- a/LEGO1/viewmanager/viewroi.h
+++ b/LEGO1/viewmanager/viewroi.h
@@ -41,7 +41,7 @@ public:
 
 protected:
 	Tgl::Group* geometry;
-	void UpdateWorldData(const MxMatrixData& parent2world);
+	void UpdateWorldData(const MatrixData& parent2world);
 };
 
 #endif // VIEWROI_H

--- a/LEGO1/viewmanager/viewroi.h
+++ b/LEGO1/viewmanager/viewroi.h
@@ -41,7 +41,7 @@ public:
 
 protected:
 	Tgl::Group* geometry;
-	void UpdateWorldData(const MatrixData& parent2world);
+	void UpdateWorldData(const Matrix4Data& parent2world);
 };
 
 #endif // VIEWROI_H


### PR DESCRIPTION
This PR cleans up some stuff but doesn't change any logic/implementation:

* Remove `mxtypes.h` dependencies from libraries
* Remove `Mx*` prefix from vector/matrix classes. The implementation classes are now suffixed with `Impl`. Right now it would be (using the example of `Vector`, but same applies to `Matrix`):

`Vector3`: Basic structure that just holds the data
`Vector3Impl`: Implements virtual functions for a `Vector3`
`Vector3Data`: Based on `Vector3Impl` but has a `Vector3` as a member

I'm open to suggestions on using different names.

Maybe the 1996 `Vector3` has actually evolved into what is now `Vector3Data` though and we shouldn't make it a separate class, but merge those two together.