### PR TITLE
Use `Vector4`/`Vector3` as members for `Vector4Data`/`Vector3Data`

### DIFF
--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -65,7 +65,7 @@ public:
 	virtual void ToQuaternion(Vector4Impl* p_resultQuat);
 	virtual int FUN_10002710(const Vector3Impl* p_vec);
 
-	inline float& operator[](size_t idx) { return (*m_data)[idx >> 2][idx & 3]; }
+	inline float& operator[](size_t idx) { return ((float*) m_data)[idx]; }
 
 protected:
 	Matrix4* m_data;
@@ -75,8 +75,8 @@ protected:
 // SIZE 0x48
 class Matrix4Data : public Matrix4Impl {
 public:
-	inline Matrix4Data() : Matrix4Impl(m) {}
-	inline Matrix4Data(Matrix4Data& p_other) : Matrix4Impl(m) { m = *p_other.m_data; }
+	inline Matrix4Data() : Matrix4Impl(m_matrix) {}
+	inline Matrix4Data(Matrix4Data& p_other) : Matrix4Impl(m_matrix) { m_matrix = *p_other.m_data; }
 	inline Matrix4& GetMatrix() { return *m_data; }
 
 	// No idea why there's another equals. Maybe to some other type like the
@@ -84,7 +84,7 @@ public:
 	// vtable + 0x44
 	virtual void operator=(const Matrix4Data& p_other);
 
-	Matrix4 m;
+	Matrix4 m_matrix;
 };
 
 #endif // MATRIX_H

--- a/LEGO1/realtime/matrix.h
+++ b/LEGO1/realtime/matrix.h
@@ -68,6 +68,7 @@ public:
 	inline float& operator[](size_t idx) { return ((float*) m_data)[idx]; }
 
 protected:
+	// TODO: Currently unclear whether this class contains a Matrix4* or float*.
 	Matrix4* m_data;
 };
 

--- a/LEGO1/realtime/vector.h
+++ b/LEGO1/realtime/vector.h
@@ -186,43 +186,31 @@ public:
 // SIZE 0x14
 class Vector3Data : public Vector3Impl {
 public:
-	inline Vector3Data() : Vector3Impl(storage) {}
-	inline Vector3Data(float p_x, float p_y, float p_z) : Vector3Impl(storage), x(p_x), y(p_y), z(p_z) {}
-
-	union {
-		float storage[3];
-		struct {
-			float x;
-			float y;
-			float z;
-		};
-	};
+	inline Vector3Data() : Vector3Impl(m_vector.elements) {}
+	inline Vector3Data(float p_x, float p_y, float p_z) : Vector3Impl(m_vector.elements), m_vector(p_x, p_y, p_z) {}
 
 	void CopyFrom(Vector3Data& p_other)
 	{
 		EqualsImpl(p_other.m_data);
 
-		float* dest = this->storage;
-		float* src = p_other.storage;
-		for (size_t i = sizeof(storage) / sizeof(float); i > 0; --i)
+		float* dest = m_vector.elements;
+		float* src = p_other.m_vector.elements;
+		for (size_t i = sizeof(m_vector) / sizeof(float); i > 0; --i)
 			*dest++ = *src++;
 	}
+
+private:
+	Vector3 m_vector;
 };
 
 // VTABLE 0x100d41e8
 // SIZE 0x18
 class Vector4Data : public Vector4Impl {
 public:
-	inline Vector4Data() : Vector4Impl(storage) {}
-	union {
-		float storage[4];
-		struct {
-			float x;
-			float y;
-			float z;
-			float w;
-		};
-	};
+	inline Vector4Data() : Vector4Impl(m_vector.elements) {}
+
+private:
+	Vector4 m_vector;
 };
 
 #endif // VECTOR_H

--- a/LEGO1/tgl/tgl.h
+++ b/LEGO1/tgl/tgl.h
@@ -303,6 +303,8 @@ public:
     virtual Result  SetOrientation(const double direction[3],
                                    const double up[3]) = 0;
 #endif
+	// TODO: The type was changed from `FloatMatrix` to `Matrix` to make code in UpdateWorldData match.
+	// However, this is unlikely to be correct and will have to be figured out at some point.
 	virtual Result SetTransformation(const Matrix4&) = 0;
 
 	// ??? not yet fully implemented


### PR DESCRIPTION
To improve consistency, this adds the structure classes as members to the `Vector` data classes, the same way as seen in `Matrix4Data`. Matches stay the same.

Also adding the comment about the `tgl.h` type change.